### PR TITLE
Update init.pp

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -75,6 +75,8 @@
 # * `version`
 #   The version of Vault to install
 #
+# * `manage_vault_utils`
+#   Instruct puppet to manage the additional utilities like openssl and jq
 # == Class vault::initialize
 # * `initialize_vault`
 #   If set to true, will initialize vault after installation.  Keys and tokens
@@ -170,6 +172,7 @@ class vault (
   Optional[Array[String]]    $vault_keys                = undef,
   Optional[Hash]             $vault_policies            = $vault::params::default_policies,
   String                     $version                   = '1.3.2',
+  Boolean                    $manage_vault_utils        = true,
 ) inherits vault::params {
 
   $_download_url     = "${download_url_base}${version}"
@@ -178,7 +181,9 @@ class vault (
   $vault_address     = "${ip_address}:${port}"
   $_vault_utils      = [ 'openssl', 'jq' ]
 
-  package { $_vault_utils: ensure => present }
+  if $manage_vault_utils {
+    package { $_vault_utils: ensure => present }
+  }
 
   contain vault::install
   contain vault::config


### PR DESCRIPTION
Retains existing functionality, but allows others that are already managing versions of the packages listed in $_vault_utils to use this module by setting $manage_vault_utils to 'false'.  We maintain base system packages (including openssl), which conflicts with the one in the module.