### PR TITLE
Invoking all vault commands in bash so HOME is picked up for vault token

### DIFF
--- a/lib/facter/vault_existing_certs.rb
+++ b/lib/facter/vault_existing_certs.rb
@@ -35,7 +35,7 @@ Facter.add(:vault_existing_certs) do
           common_name = common_name_utf8.encode('ASCII',
                                                 invalid: :replace,
                                                 undef: :replace,
-                                                replace: "_")
+                                                replace: '_')
           certs[cert_path] = {
             'common_name' => common_name,
             'cert_name' => cert_name,

--- a/manifests/config/initialize.pp
+++ b/manifests/config/initialize.pp
@@ -11,7 +11,7 @@ class vault::config::initialize (
 ) inherits vault {
 
   $_init_cmd = @("EOC")
-    bash -c "vault operator init \
+    bash -lc "${bin_dir}/vault operator init \
       -key-shares=${total_keys} \
       -key-threshold=${minimum_keys} \
       > ${vault_dir}/vault_init.txt"
@@ -19,9 +19,10 @@ class vault::config::initialize (
 
   if $facts['vault_initialized'] != true {
     exec { 'vault_initialize':
-      path    => [$bin_dir, '/bin', '/usr/bin'],
-      command => $_init_cmd,
-      creates => "${vault_dir}/vault_init.txt",
+      path     => [$bin_dir, '/bin', '/usr/bin'],
+      command  => $_init_cmd,
+      creates  => "${vault_dir}/vault_init.txt",
+      provider => 'shell',
     }
 
     file { "${vault_dir}/vault_init.txt":

--- a/manifests/config/initialize.pp
+++ b/manifests/config/initialize.pp
@@ -11,10 +11,10 @@ class vault::config::initialize (
 ) inherits vault {
 
   $_init_cmd = @("EOC")
-    vault operator init \
+    bash -c "vault operator init \
       -key-shares=${total_keys} \
       -key-threshold=${minimum_keys} \
-      > ${vault_dir}/vault_init.txt
+      > ${vault_dir}/vault_init.txt"
     | EOC
 
   if $facts['vault_initialized'] != true {

--- a/manifests/config/ldap.pp
+++ b/manifests/config/ldap.pp
@@ -32,8 +32,8 @@ define vault::config::ldap (
     | EOC
 
   $_ldap_auth_check_cmd = @("EOC")
-    ${bin_dir}/vault auth list -format=json |\
-      jq '.[] | {message: .type}' | grep -q 'ldap'
+    bash -c "${bin_dir}/vault auth list -format=json |\
+      jq '.[] | {message: .type}' | grep -q 'ldap'"
     | EOC
 
   if $ldap_url == undef {
@@ -54,14 +54,14 @@ define vault::config::ldap (
 
   exec { 'vault_ldap_enable':
     path    => [ $bin_dir, '/bin', '/usr/bin' ],
-    command => 'vault auth enable ldap',
+    command => 'bash -c "vault auth enable ldap"',
     #environment => [ "VAULT_TOKEN=${vault_token}" ],
     unless  => $_ldap_auth_check_cmd,
     require => Exec["${vault_dir}/scripts/unseal.sh"],
   }
 
   $_ldap_config_cmd = @("EOC")
-    vault write auth/ldap/config \
+    bash -c "vault write auth/ldap/config \
       url='${_ldap_url}' \
       starttls='${starttls}' \
       insecure_tls='${insecure_tls}' \
@@ -72,7 +72,7 @@ define vault::config::ldap (
       userattr='${user_attr}' \
       groupdn='${group_dn}' \
       groupattr='${group_attr}' \
-      groupfilter='${group_filter}'
+      groupfilter='${group_filter}'"
     | EOC
 
   $_safe_ldap_cmd = regsubst($_ldap_config_cmd, "bindpass='.* ", "bindpass='********' ",)

--- a/manifests/config/ldap.pp
+++ b/manifests/config/ldap.pp
@@ -32,9 +32,13 @@ define vault::config::ldap (
     | EOC
 
   $_ldap_auth_check_cmd = @("EOC")
-    bash -c "${bin_dir}/vault auth list -format=json |\
+    bash -lc "${bin_dir}/vault auth list -format=json |\
       jq '.[] | {message: .type}' | grep -q 'ldap'"
-    | EOC
+  | EOC
+
+  $_ldap_auth_cmd = @("EOC")
+    bash -lc "${bin_dir}/vault auth enable ldap"
+  | EOC
 
   if $ldap_url == undef {
     $_ldap_url = $ldap_servers.map |$server| { "ldap://${server}" }.join(',')
@@ -47,21 +51,23 @@ define vault::config::ldap (
   contain vault::config::unseal
 
   exec { "${ldap_servers[0]}.crt":
-    path    => [ '/bin', '/usr/bin' ],
-    command => $_ldap_cert_cmd,
-    creates => $_ldap_cert,
+    path     => [ '/bin', '/usr/bin' ],
+    command  => $_ldap_cert_cmd,
+    creates  => $_ldap_cert,
+    provider => 'shell',
   }
 
   exec { 'vault_ldap_enable':
-    path    => [ $bin_dir, '/bin', '/usr/bin' ],
-    command => 'bash -c "vault auth enable ldap"',
+    path     => [ $bin_dir, '/bin', '/usr/bin' ],
+    command  => $_ldap_auth_cmd,
     #environment => [ "VAULT_TOKEN=${vault_token}" ],
-    unless  => $_ldap_auth_check_cmd,
-    require => Exec["${vault_dir}/scripts/unseal.sh"],
+    unless   => $_ldap_auth_check_cmd,
+    provider => 'shell',
+    require  => Exec["${vault_dir}/scripts/unseal.sh"],
   }
 
   $_ldap_config_cmd = @("EOC")
-    bash -c "vault write auth/ldap/config \
+    bash -lc "${bin_dir}/vault write auth/ldap/config \
       url='${_ldap_url}' \
       starttls='${starttls}' \
       insecure_tls='${insecure_tls}' \
@@ -73,7 +79,7 @@ define vault::config::ldap (
       groupdn='${group_dn}' \
       groupattr='${group_attr}' \
       groupfilter='${group_filter}'"
-    | EOC
+  | EOC
 
   $_safe_ldap_cmd = regsubst($_ldap_config_cmd, "bindpass='.* ", "bindpass='********' ",)
 
@@ -89,6 +95,7 @@ define vault::config::ldap (
   exec { "ldap_config_${name}":
     path        => [ $bin_dir, '/bin', '/usr/bin' ],
     command     => $_ldap_config_cmd,
+    provider    => 'shell',
     #environment => [ "VAULT_TOKEN=${vault_token}" ],
     refreshonly => true,
   }

--- a/manifests/config/ldap_groups.pp
+++ b/manifests/config/ldap_groups.pp
@@ -6,18 +6,19 @@ define vault::config::ldap_groups (
 ) {
 
   $_group_add_cmd = @("EOC")
-    bash -c "vault write auth/ldap/groups/${group} policies=${policy}"
+    bash -lc "${bin_dir}/vault write auth/ldap/groups/${group} policies=${policy}"
     | EOC
   $_group_check_cmd = @("EOC")
-    bash -c "${bin_dir}/vault read -format=json auth/ldap/groups/${group} |\
-      jq .data.policies | grep -q '${policy}'"
+    bash -lc "${bin_dir}/vault read -format=json auth/ldap/groups/${group} |\
+      jq .data.policies | grep -q \"${policy}\""
     | EOC
 
   exec { "vault_${group}":
-    path    => [ $bin_dir, '/bin', '/usr/local/bin' ],
-    command => $_group_add_cmd,
+    path     => [ $bin_dir, '/bin', '/usr/local/bin' ],
+    command  => $_group_add_cmd,
     #environment => [ "VAULT_TOKEN=${vault_token}" ],
-    unless  => $_group_check_cmd,
+    unless   => $_group_check_cmd,
+    provider => 'shell',
   }
 
 }

--- a/manifests/config/ldap_groups.pp
+++ b/manifests/config/ldap_groups.pp
@@ -6,11 +6,11 @@ define vault::config::ldap_groups (
 ) {
 
   $_group_add_cmd = @("EOC")
-    vault write auth/ldap/groups/${group} policies=${policy}
+    bash -c "vault write auth/ldap/groups/${group} policies=${policy}"
     | EOC
   $_group_check_cmd = @("EOC")
-    ${bin_dir}/vault read -format=json auth/ldap/groups/${group} |\
-      jq .data.policies | grep -q "${policy}"
+    bash -c "${bin_dir}/vault read -format=json auth/ldap/groups/${group} |\
+      jq .data.policies | grep -q '${policy}'"
     | EOC
 
   exec { "vault_${group}":

--- a/manifests/config/policy.pp
+++ b/manifests/config/policy.pp
@@ -35,7 +35,9 @@ define vault::config::policy (
   }
 
   ## Write defined policy to vault if file content changed.
-  $_policy_write_cmd = "vault policy write '${name}' '${_policy_file}'"
+  $_policy_write_cmd = @("EOC")
+    bash -c "vault policy write '${name}' '${_policy_file}'"
+  | EOC
 
   exec { "write_${name}":
     command     => $_policy_write_cmd,

--- a/manifests/config/policy.pp
+++ b/manifests/config/policy.pp
@@ -36,7 +36,7 @@ define vault::config::policy (
 
   ## Write defined policy to vault if file content changed.
   $_policy_write_cmd = @("EOC")
-    bash -c "vault policy write '${name}' '${_policy_file}'"
+    bash -lc "${bin_dir}/vault policy write '${name}' '${_policy_file}'"
   | EOC
 
   exec { "write_${name}":
@@ -44,6 +44,7 @@ define vault::config::policy (
     #environment => [ "VAULT_TOKEN=${vault_token}" ],
     path        => [ $bin_dir, '/bin', '/usr/bin' ],
     refreshonly => true,
+    provider    => 'shell',
     subscribe   => File[$_policy_file],
   }
 

--- a/manifests/config/unseal.pp
+++ b/manifests/config/unseal.pp
@@ -30,9 +30,10 @@ class vault::config::unseal (
 
   ## Unseal vault
   exec { "${vault_dir}/scripts/unseal.sh":
-    path    => [ $bin_dir, '/bin', '/usr/bin' ],
-    require => File["${vault_dir}/scripts/unseal.sh"],
-    unless  => "${bin_dir}/vault status",
+    path     => [ $bin_dir, '/bin', '/usr/bin' ],
+    require  => File["${vault_dir}/scripts/unseal.sh"],
+    unless   => "${bin_dir}/vault status",
+    provider => 'shell',
   }
 
 }

--- a/manifests/pki/config.pp
+++ b/manifests/pki/config.pp
@@ -13,9 +13,11 @@ define vault::pki::config (
     $_options = join($options.map |$key, $value| { "${key}='${value}'" }, ' ')
   }
 
-  $_config_cmd = "vault ${action} ${path} ${_options}"
+  $_config_cmd = @("EOC")
+    bash -c "vault ${action} ${path} ${_options}"
+  | EOC
 
-  ## Used for idempotencey 
+  ## Used for idempotencey
   $_file_name = regsubst($path, '/', '_', 'G')
   file { "${vault::install_dir}/scripts/.pki_config_${_file_name}.cmd":
     ensure  => file,

--- a/manifests/pki/config.pp
+++ b/manifests/pki/config.pp
@@ -14,7 +14,7 @@ define vault::pki::config (
   }
 
   $_config_cmd = @("EOC")
-    bash -c "vault ${action} ${path} ${_options}"
+    bash -lc "${vault::bin_dir}/vault ${action} ${path} ${_options}"
   | EOC
 
   ## Used for idempotencey
@@ -30,6 +30,7 @@ define vault::pki::config (
     command     => $_config_cmd,
     path        => [ $vault::bin_dir, '/bin', '/usr/bin' ],
     refreshonly => true,
+    provider    => 'shell',
   }
 
 }

--- a/manifests/pki/generate_cert.pp
+++ b/manifests/pki/generate_cert.pp
@@ -1,4 +1,4 @@
-# @api private == define class to generate pki certificates 
+# @api private == define class to generate pki certificates
 define vault::pki::generate_cert (
   String                             $bin_dir          = $vault::bin_dir,
   Optional[Hash]                     $cert_options     = undef,
@@ -27,13 +27,19 @@ define vault::pki::generate_cert (
 
   if $is_root_ca {
     # Remove existing root certificate
-    $_clear_cert_cmd = "vault delete ${path}/root"
+    $_clear_cert_cmd = @("EOC")
+      bash -c "vault delete ${path}/root"
+    | EOC
   } else {
     if ! empty($cert_sn) {
       # Revoke existing certificate
-      $_clear_cert_cmd = "vault write ${path}/revoke serial_number=${cert_sn}"
+      $_clear_cert_cmd = @("EOC")
+        bash -c "vault write ${path}/revoke serial_number=${cert_sn}"
+      | EOC
     } else {
-      $_clear_cert_cmd = 'vault status'
+      $_clear_cert_cmd = @("EOC")
+        "vault status"
+      | EOC
     }
   }
 

--- a/manifests/pki/int_ca.pp
+++ b/manifests/pki/int_ca.pp
@@ -39,9 +39,9 @@ define vault::pki::int_ca (
   ## Sign the intermediate CA with root if true and root CA enabled.
   if $sign_intermediate and $enable_root_ca {
     $_sign_int_ca_cmd = @("EOC")
-      vault write -format=json ${root_path}/root/sign-intermediate \
+      bash -c "vault write -format=json ${root_path}/root/sign-intermediate \
         csr=@${cert_csr} format=pem_bundle ttl='${ttl}' |\
-        jq -r '.data.certificate' > ${cert}
+        jq -r '.data.certificate' > ${cert}"
       | EOC
 
     ## Sign the intermediate CA CSR
@@ -65,7 +65,9 @@ define vault::pki::int_ca (
     }
 
     ## Import signed intermediate CA certificate
-    $_import_int_ca_cert = "vault write ${path}/intermediate/set-signed certificate=@${cert}"
+    $_import_int_ca_cert = @("EOC")
+      bash -c "vault write ${path}/intermediate/set-signed certificate=@${cert}"
+    | EOC
 
     exec { 'import_cert':
       command     => $_import_int_ca_cert,

--- a/manifests/secrets/engine.pp
+++ b/manifests/secrets/engine.pp
@@ -36,11 +36,13 @@ define vault::secrets::engine (
     $_check_secret_cmd = 'false'
   } else {
     $_secret_cmd = @("EOC")
-      vault secrets ${action} \
-        -description="Puppet managed ${engine} engine" \
-        -path=${path} ${_options} ${engine}
+      bash -c "vault secrets ${action} \
+        -description='Puppet managed ${engine} engine' \
+        -path=${path} ${_options} ${engine}"
       | EOC
-    $_check_secret_cmd = "vault secrets list | grep -q '${path}/'"
+    $_check_secret_cmd = @("EOC")
+      bash -c "vault secrets list | grep -q '${path}/'"
+    | EOC
   }
 
   ## Perform selected action

--- a/manifests/secrets/engine.pp
+++ b/manifests/secrets/engine.pp
@@ -33,25 +33,26 @@ define vault::secrets::engine (
   ## Build vault command
   if $action == 'disable' {
     $_secret_cmd = @("EOC")
-      bash -c "vault secrets ${action} ${path}"
+      bash -lc "${vault::bin_dir}/vault secrets ${action} ${path}"
     | EOC
     $_check_secret_cmd = 'false'
   } else {
-    $_secret_cmd = @("EOC")
-      bash -c "vault secrets ${action} \
-        -description='Puppet managed ${engine} engine' \
+    $_secret_cmd = @("EOC"/L)
+      bash -lc "${vault::bin_dir}/vault secrets ${action} \
+        -description=\"Puppet managed ${engine} engine\" \
         -path=${path} ${_options} ${engine}"
-      | EOC
+    | EOC
     $_check_secret_cmd = @("EOC")
-      bash -c "vault secrets list | grep -q '${path}/'"
+      bash -lc "${vault::bin_dir}/vault secrets list | grep -q \"${path}/\""
     | EOC
   }
 
   ## Perform selected action
   exec { "pki_enable_${path}":
-    command => $_secret_cmd,
-    path    => [ $vault::bin_dir, '/bin', '/usr/bin' ],
-    unless  => $_check_secret_cmd,
+    command  => $_secret_cmd,
+    path     => [ $vault::bin_dir, '/bin', '/usr/bin' ],
+    unless   => $_check_secret_cmd,
+    provider => 'shell',
   }
 
 }

--- a/manifests/secrets/engine.pp
+++ b/manifests/secrets/engine.pp
@@ -32,7 +32,9 @@ define vault::secrets::engine (
 
   ## Build vault command
   if $action == 'disable' {
-    $_secret_cmd = "vault secrets ${action} ${path}"
+    $_secret_cmd = @("EOC")
+      bash -c "vault secrets ${action} ${path}"
+    | EOC
     $_check_secret_cmd = 'false'
   } else {
     $_secret_cmd = @("EOC")


### PR DESCRIPTION
Wraps all vault commands in `bash -c` so that `$HOME` is picked up so it can read from `~/.vault-token`