### PR TITLE
Move directory check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2020-02-01 2.3.0
+- Moved directory check out of type definition to provider so that it is checking when at
+  execution not before since directory may be created during the profile run
+
 ## 2020-02-01 2.2.0
 - Add support for `api_addr` stanza
 - Update to vault 1.3.2

--- a/lib/puppet/provider/vault_cert/openssl.rb
+++ b/lib/puppet/provider/vault_cert/openssl.rb
@@ -54,6 +54,12 @@ Puppet::Type.type(:vault_cert).provide(:openssl, parent: Puppet::Provider::Vault
   # Save an openssl cert object into the global cert var
   def certificate
     return @cert unless @cert.nil?
+
+    # Verify that the given directory exists
+    unless File.directory?(resource[:cert_dir])
+      raise ArgumentError, "Directory not found for: #{resource[:cert_dir]}"
+    end
+
     cert_path = File.join(resource[:cert_dir], resource[:cert_name])
     @cert = if Pathname.new(cert_path).exist?
               file = File.read(cert_path)
@@ -66,6 +72,12 @@ Puppet::Type.type(:vault_cert).provide(:openssl, parent: Puppet::Provider::Vault
   # Save an openssl PKey object into the global priv_key var
   def private_key
     return @priv_key unless @priv_key.nil?
+
+    # Verify that the given directory exists
+    unless File.directory?(resource[:priv_key_dir])
+      raise ArgumentError, "Directory not found for: #{resource[:priv_key_dir]}"
+    end
+
     priv_key_path = File.join(resource[:priv_key_dir], resource[:priv_key_name])
     @priv_key = if Pathname.new(priv_key_path).exist?
                   file = File.read(priv_key_path)

--- a/lib/puppet/type/vault_cert.rb
+++ b/lib/puppet/type/vault_cert.rb
@@ -99,10 +99,6 @@ Puppet::Type.newtype(:vault_cert) do
         unless path.absolute?
           raise ArgumentError, "Path must be absolute: #{value}"
         end
-        # Verify that the given directory exists
-        unless File.directory?(value)
-          raise ArgumentError, "Directory not found for: #{value}"
-        end
       else
         unless value.start_with?('Cert:\\')
           raise ArgumentError, "Windows paths must start with Cert:\\ : #{value}"
@@ -176,10 +172,6 @@ Puppet::Type.newtype(:vault_cert) do
         # Verify that an absolute path was given
         unless path.absolute?
           raise ArgumentError, "Path must be absolute: #{path}"
-        end
-        # Verify that the given directory exists
-        unless File.directory?(value)
-          raise ArgumentError, "Directory not found for: #{value}"
         end
       else
         unless value.start_with?('Cert:\\')

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "jsok-vault",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "author": "jsok",
   "summary": "Puppet module to manage Vault (https://vaultproject.io)",
   "license": "Apache-2.0",


### PR DESCRIPTION
Issue that when in a profile that has other things happening the module is expecting the directory to exist when specifying the type. Where is our case the directory is created during the puppet run and before the cert is created. 

error:
```
Error: Failed to apply catalog: Parameter cert_dir failed on Vault_cert[st2]: Directory not found for: /etc/ssl/st2 (file: /etc/puppetlabs/code/environments/development/modules/vault/manifests/cert.pp, line: 50)
```

The solution to this was to move the directory check code out of the type definition and into the provider code so that the directory check happens at execution instead of before the puppet run.