### PR TITLE
Certificates with CA chains

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
 ## Development
 
+## 2024-01-09 2.6.0
+- Fixing certificate to contain whole CA chain that is returned
+  as apart of the API call.
+  Contributed by Bradley Bishop (@bishopbm1)
 - Switch from Travis to GitHub Actions
-
   Contributed by Nick Maludy (@nmaludy)
 
 ## 2023-10-15 2.5.0

--- a/lib/puppet/provider/vault_cert/openssl.rb
+++ b/lib/puppet/provider/vault_cert/openssl.rb
@@ -109,10 +109,10 @@ Puppet::Type.type(:vault_cert).provide(:openssl, parent: Puppet::Provider::Vault
       cert_ca_chain = cert['data']['ca_chain']
       if cert_ca_chain.is_a?(Array)
         for ca in cert_ca_chain
-          signed_cert += ca
           if not signed_cert.end_with?("\n")
             signed_cert += "\n"
           end
+          signed_cert += ca
         end
       else
         signed_cert += cert_ca_chain

--- a/lib/puppet/provider/vault_cert/openssl.rb
+++ b/lib/puppet/provider/vault_cert/openssl.rb
@@ -102,8 +102,25 @@ Puppet::Type.type(:vault_cert).provide(:openssl, parent: Puppet::Provider::Vault
   def client_cert_save(cert)
     # Get the cert path from the directory and name
     # Save the new cert in the certs directory on the client server
+    signed_cert = cert['data']['certificate']
+
+    # append the CA chain to the signed cert
+    if cert['data'].has_key?('ca_chain')
+      cert_ca_chain = cert['data']['ca_chain']
+      if cert_ca_chain.is_a?(Array)
+        for ca in cert_ca_chain
+          signed_cert += ca
+          if not signed_cert.end_with?("\n")
+            signed_cert += "\n"
+          end
+        end
+      else
+        signed_cert += cert_ca_chain
+      end
+    end
+
     write_file(resource[:cert_dir], resource[:cert_name],
-               cert['data']['certificate'])
+               signed_cert)
 
     # Get the private key path from the directory and name
     # Save the new private key in the tls directory on the client

--- a/lib/puppet/provider/vault_cert/powershell.rb
+++ b/lib/puppet/provider/vault_cert/powershell.rb
@@ -58,6 +58,22 @@ Puppet::Type.type(:vault_cert).provide(:powershell, parent: Puppet::Provider::Va
       Puppet.debug('creating from new cert from vault')
       new_cert = create_cert
       cert = new_cert['data']['certificate']
+
+      # append the CA chain to the signed cert
+      if new_cert['data'].has_key?('ca_chain')
+        cert_ca_chain = new_cert['data']['ca_chain']
+        if cert_ca_chain.is_a?(Array)
+          for ca in cert_ca_chain
+            if not cert.end_with?("\n")
+              cert += "\n"
+            end
+            cert += ca
+          end
+        else
+          cert += cert_ca_chain
+        end
+      end
+
       priv_key = new_cert['data']['private_key']
     end
 

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "jsok-vault",
-  "version": "2.5.0",
+  "version": "2.6.0",
   "author": "jsok",
   "summary": "Puppet module to manage Vault (https://vaultproject.io)",
   "license": "Apache-2.0",


### PR DESCRIPTION
Added logic for both Windows and Linux systems to include the CA chain that is included in the API response but was not set in the file system.